### PR TITLE
allowed make_image_name to pass in a NULL image and return a NULL output

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -44,6 +44,9 @@ has_registry_prefix <- function(name) {
 }
 
 make_image_name <- function(name, projectId) {
+  if (is.null(name)) {
+    return(name)
+  }
   prefix <- has_registry_prefix(name)
   if (prefix) {
     the_image <- name


### PR DESCRIPTION
The issue is that in `docker` steps, if you do not want to to push an image (only build it), you may want to put in a `NULL` image so that `pushed_image` returns NULL and the `push_image` step gives nothing: https://github.com/MarkEdmondson1234/googleCloudRunner/blob/075aff754cf8191cde5f3f0894c2fba8c7062bf0/R/docker.R#L378