### PR TITLE
adding a quick check to see if that package exists

### DIFF
--- a/R/build_sources.R
+++ b/R/build_sources.R
@@ -348,8 +348,11 @@ cr_build_upload_gcs <- function(local,
 #'
 cr_buildstep_source_move <- function(deploy_folder){
   cr_buildstep_bash(
-    sprintf("ls -R /workspace/ && cd /workspace/%s && mv * ../ && ls -R /workspace/",
-            deploy_folder),
+    sprintf(
+      paste0("ls -R /workspace/; ",
+             '[ -d "/workspace/%s" ] && ',
+             "cd /workspace/%s && mv * ../; ls -R /workspace/"),
+      deploy_folder, deploy_folder),
     id = "move source files"
   )
 }


### PR DESCRIPTION
This is a simple check/safeguard that won't fail if things are already moved.  I shouldn't happen many times, but I ran into it once (particularly on **rerunning** of the same code).  This is a benign check otherwise, but won't hurt. 