### PR TITLE
fix for when authorized but auth_file is not given

### DIFF
--- a/R/rstudio_gadget.R
+++ b/R/rstudio_gadget.R
@@ -7,12 +7,12 @@ cr_deploy_gadget <- function() {
   assert_that(
     cr_project_get() != "",
     cr_bucket_get() != "",
-    cr_region_get() != "",
-    Sys.getenv("GCE_AUTH_FILE") != ""
+    cr_region_get() != ""
   )
 
   # if invoked when the library is not loaded
   if (!googleAuthR::gar_has_token()) {
+    assertthat::assert_that(Sys.getenv("GCE_AUTH_FILE") != "")
     googleAuthR::gar_attach_auto_auth(
       "https://www.googleapis.com/auth/cloud-platform",
       environment_var = "GCE_AUTH_FILE"


### PR DESCRIPTION
If you are authorized already, but don't have `GCE_AUTH_FILE` set (which is my common use case on GCE), then this will fail.  I put the check for `GCE_AUTH_FILE` in the spot if you don't have a token.