### PR TITLE
allowing certain pass through arguments

### DIFF
--- a/R/docker.R
+++ b/R/docker.R
@@ -46,7 +46,8 @@ cr_deploy_docker_trigger <- function(repo,
         projectId = projectId_target,
         ...,
         kaniko_cache = TRUE
-      )
+      ),
+      timeout = timeout
     ),
     timeout = timeout
   )
@@ -140,7 +141,8 @@ cr_deploy_docker <- function(local,
     result$build_yaml,
     source = result$gcs_source,
     launch_browser = launch_browser,
-    timeout = result$timeout
+    timeout = result$timeout,
+    projectId = projectId
   )
 
   b <- cr_build_wait(docker_build, projectId = result$projectId)


### PR DESCRIPTION
projectId should be able to pass through so `cr_project_get` isn't invoked and I believe you need to pass `timeout` to `cr_build_yaml`, but doing so just in case.