### PR TITLE
Cloudbuild schedule

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     googlePubsubR (>= 0.0.2),
     httr (>= 1.4.1),
     jose (>= 1.0),
+    methods,
     jsonlite (>= 1.5),
     openssl (>= 1.4.1),
     plumber (>= 1.0.0),

--- a/R/cloudbuild_schedule.R
+++ b/R/cloudbuild_schedule.R
@@ -174,8 +174,7 @@ cr_schedule_build <- function(build,
 
 }
 
-check_pubsub_topic <- function(schedule_pubsub, run_name,
-                               projectId){
+check_pubsub_topic <- function(schedule_pubsub, run_name){
   if (!is.null(schedule_pubsub)) {
     assert_that(is.gar_pubsubTarget(schedule_pubsub))
     topic_basename <- basename(schedule_pubsub$topicName)
@@ -207,7 +206,6 @@ check_topic_exists <- function(topic) {
   }, silent = TRUE)
   !inherits(x, "try-error")
 }
-
 trigger_exists = function(...) {
   x = try({
     cr_buildtrigger_get(...)
@@ -221,8 +219,7 @@ create_pubsub_target <- function(build, schedule_pubsub, run_name,
                                  trigger_name = NULL,
                                  ...) {
 
-  topic_basename <- check_pubsub_topic(schedule_pubsub, run_name,
-                                       projectId)
+  topic_basename <- check_pubsub_topic(schedule_pubsub, run_name)
   if (!is.null(schedule_pubsub)) {
     assert_that(is.gar_pubsubTarget(schedule_pubsub))
     # so it will pass cr_schedule_pubsub

--- a/R/cloudbuild_schedule.R
+++ b/R/cloudbuild_schedule.R
@@ -21,10 +21,7 @@ cr_build_schedule_http <- function(build,
 #'
 #' @return \code{cr_schedule_http} returns a \link{HttpTarget} object for use in \link{cr_schedule}
 #'
-#' @details Ensure you have a service email with \link{cr_email_set} of format
-#' \code{service-{project-number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com}
-#' with Cloud Scheduler Service Agent role as per
-#' https://cloud.google.com/scheduler/docs/http-target-auth#add
+#' @details Ensure you have a service email with \link{cr_email_set} of format \code{service-{project-number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com} with Cloud Scheduler Service Agent role as per https://cloud.google.com/scheduler/docs/http-target-auth#add
 #'
 #' @export
 #' @import assertthat
@@ -177,17 +174,10 @@ cr_schedule_build <- function(build,
 
 }
 
-check_topic_exists <- function(topic) {
-  x <- try({
-    googlePubsubR::topics_get(topic)
-  }, silent = TRUE)
-  !inherits(x, "try-error")
-}
-
 check_pubsub_topic <- function(schedule_pubsub, run_name,
                                projectId){
   if (!is.null(schedule_pubsub)) {
-    assertthat::assert_that(is.gar_pubsubTarget(schedule_pubsub))
+    assert_that(is.gar_pubsubTarget(schedule_pubsub))
     topic_basename <- basename(schedule_pubsub$topicName)
   } else {
     topic_basename <- paste0(run_name, "-topic")
@@ -209,7 +199,13 @@ check_pubsub_topic <- function(schedule_pubsub, run_name,
   }
 
   topic_basename
+}
 
+check_topic_exists <- function(topic) {
+  x <- try({
+    googlePubsubR::topics_get(topic)
+  }, silent = TRUE)
+  !inherits(x, "try-error")
 }
 
 trigger_exists = function(...) {
@@ -228,7 +224,7 @@ create_pubsub_target <- function(build, schedule_pubsub, run_name,
   topic_basename <- check_pubsub_topic(schedule_pubsub, run_name,
                                        projectId)
   if (!is.null(schedule_pubsub)) {
-    assertthat::assert_that(is.gar_pubsubTarget(schedule_pubsub))
+    assert_that(is.gar_pubsubTarget(schedule_pubsub))
     # so it will pass cr_schedule_pubsub
     # reverse the order it does in PubsubTarget creation
     schedule_pubsub$data = jsonlite::fromJSON(
@@ -290,13 +286,9 @@ create_pubsub_target <- function(build, schedule_pubsub, run_name,
 #'
 #' @details
 #'
-#' You can parametrise builds by sending in values within PubSub. To read
-#' the data in the message set a substitution variable that picks up the data.
-#' For example \code{_VAR1=$(body.message.data.var1)}
+#' You can parametrise builds by sending in values within PubSub. To read the data in the message set a substitution variable that picks up the data. For example \code{_VAR1=$(body.message.data.var1)}
 #'
-#' If your schedule to PubSub fails with a permission error, try turning the
-#' Cloud Scheduler API off and on again the Cloud Console, which will
-#' refresh the Google permissions.
+#' If your schedule to PubSub fails with a permission error, try turning the Cloud Scheduler API off and on again the Cloud Console, which will refresh the Google permissions.
 #'
 #' @examples
 #' cr_project_set("my-project")
@@ -358,17 +350,17 @@ cr_schedule_pubsub <- function(topicName,
                                attributes = NULL,
                                projectId = cr_project_get()) {
 
-  assertthat::assert_that(
-    assertthat::is.string(projectId)
+  assert_that(
+    is.string(projectId)
   )
 
-  if (assertthat::is.string(topicName)) {
+  if (is.string(topicName)) {
     the_name <- sprintf("projects/%s/topics/%s", projectId, topicName)
   } else if(inherits(topicName, "Topic")){
     the_name <- topicName$name
   }
 
-  assertthat::assert_that(assertthat::is.string(the_name))
+  assert_that(is.string(the_name))
 
   if (is.null(data)) {
     the_data <- the_name

--- a/man/cr_schedule.Rd
+++ b/man/cr_schedule.Rd
@@ -44,7 +44,10 @@ cr_schedule(
 
 \item{topicName}{The name of the Cloud Pub/Sub topic or a Topic object from \link[googlePubsubR]{topics_get}}
 
-\item{PubsubMessage}{A \code{PubsubMessage} object generated via \link[googlePubsubR]{PubsubMessage}.  If used, then do not send in `data` or `attributes` arguments as will be redundant since this variable will hold the information.}
+\item{PubsubMessage}{A \code{PubsubMessage} object generated via
+\link[googlePubsubR]{PubsubMessage}.  If used, then do not send in
+`data` or `attributes` arguments as will be redundant since this
+variable will hold the information.}
 
 \item{data}{The message payload for PubsubMessage. An R object that will be turned into JSON via [jsonlite] and then base64 encoded into the PubSub format.}
 
@@ -77,11 +80,18 @@ A \code{gar_scheduleJob} class object
 This enables Cloud Scheduler to trigger Cloud Builds
 }
 \details{
-Ensure you have a service email with \link{cr_email_set} of format \code{service-{project-number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com} with Cloud Scheduler Service Agent role as per https://cloud.google.com/scheduler/docs/http-target-auth#add
+Ensure you have a service email with \link{cr_email_set} of format
+\code{service-{project-number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com}
+with Cloud Scheduler Service Agent role as per
+https://cloud.google.com/scheduler/docs/http-target-auth#add
 
-You can parametrise builds by sending in values within PubSub. To read the data in the message set a substitution variable that picks up the data.  For example \code{_VAR1=$(body.message.data.var1)}
+You can parametrise builds by sending in values within PubSub. To read
+the data in the message set a substitution variable that picks up the data.
+For example \code{_VAR1=$(body.message.data.var1)}
 
-If your schedule to PubSub fails with a permission error, try turning the Cloud Scheduler API off and on again the Cloud Console, which will refresh the Google permissions.
+If your schedule to PubSub fails with a permission error, try turning the
+Cloud Scheduler API off and on again the Cloud Console, which will
+refresh the Google permissions.
 }
 \examples{
 cloudbuild <- system.file("cloudbuild/cloudbuild.yaml", package = "googleCloudRunner")

--- a/man/cr_schedule.Rd
+++ b/man/cr_schedule.Rd
@@ -80,18 +80,11 @@ A \code{gar_scheduleJob} class object
 This enables Cloud Scheduler to trigger Cloud Builds
 }
 \details{
-Ensure you have a service email with \link{cr_email_set} of format
-\code{service-{project-number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com}
-with Cloud Scheduler Service Agent role as per
-https://cloud.google.com/scheduler/docs/http-target-auth#add
+Ensure you have a service email with \link{cr_email_set} of format \code{service-{project-number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com} with Cloud Scheduler Service Agent role as per https://cloud.google.com/scheduler/docs/http-target-auth#add
 
-You can parametrise builds by sending in values within PubSub. To read
-the data in the message set a substitution variable that picks up the data.
-For example \code{_VAR1=$(body.message.data.var1)}
+You can parametrise builds by sending in values within PubSub. To read the data in the message set a substitution variable that picks up the data. For example \code{_VAR1=$(body.message.data.var1)}
 
-If your schedule to PubSub fails with a permission error, try turning the
-Cloud Scheduler API off and on again the Cloud Console, which will
-refresh the Google permissions.
+If your schedule to PubSub fails with a permission error, try turning the Cloud Scheduler API off and on again the Cloud Console, which will refresh the Google permissions.
 }
 \examples{
 cloudbuild <- system.file("cloudbuild/cloudbuild.yaml", package = "googleCloudRunner")

--- a/man/cr_schedule_build.Rd
+++ b/man/cr_schedule_build.Rd
@@ -8,13 +8,14 @@ cr_schedule_build(
   build,
   schedule,
   schedule_type = c("http", "pubsub"),
-  email = cr_email_get(),
+  email = NULL,
   projectId = cr_project_get(),
+  schedule_pubsub = NULL,
   ...
 )
 }
 \arguments{
-\item{build}{A Build object}
+\item{build}{A \link{Build} object created via \link{cr_build_make} or \link{cr_build}}
 
 \item{schedule}{A cron schedule e.g. \code{"15 5 * * *"}}
 
@@ -23,6 +24,9 @@ cr_schedule_build(
 \item{email}{The email that will authenticate the job set via \link{cr_email_set}}
 
 \item{projectId}{The GCP project to run within usually set with \link{cr_project_set}}
+
+\item{schedule_pubsub}{If you have a custom pubsub message to send via
+an existing topic, use \link{cr_schedule_pubsub} to supply it here}
 
 \item{...}{
   Arguments passed on to \code{\link[=cr_schedule]{cr_schedule}}


### PR DESCRIPTION
The goals of this PR are:
1. to not fail if `email` is not set and you're using `pubsubTarget`.
2. Allow you to construct `pubsub_target` from `create_pubsub_target` if not passed in.
3. Check if a trigger exists and create it if not.
4. Checks to see if a topic exists before trying to create, which was causing silent bugs as the `tryCatch` would fail, not because it could not create the topic, but that it already existed.
5. Allow for a different message to be passed to a pubsub target in this `cr_schedule_build`