### PR TITLE
feat: allow availableSecrets and build_args

### DIFF
--- a/R/docker.R
+++ b/R/docker.R
@@ -118,6 +118,7 @@ cr_deploy_docker <- function(local,
                              predefinedAcl = "bucketOwnerFullControl",
                              pre_steps = NULL,
                              post_steps = NULL,
+                             availableSecrets = NULL,
                              ...) {
   result <- cr_deploy_docker_construct(
     local = local,
@@ -133,6 +134,7 @@ cr_deploy_docker <- function(local,
     predefinedAcl = predefinedAcl,
     pre_steps = pre_steps,
     post_steps = post_steps,
+    availableSecrets = availableSecrets,
     ...
   )
 
@@ -180,8 +182,8 @@ cr_deploy_docker_construct <- function(
   predefinedAcl = "bucketOwnerFullControl",
   pre_steps = NULL,
   post_steps = NULL,
+  availableSecrets = NULL,
   ...) {
-
   assert_that(
     dir.exists(local)
   )
@@ -237,7 +239,8 @@ cr_deploy_docker_construct <- function(
   )
   build_yaml <- cr_build_yaml(
     steps = steps,
-    images = pushed_image
+    images = pushed_image,
+    availableSecrets = availableSecrets
   )
 
   list(
@@ -402,6 +405,7 @@ cr_buildstep_docker <- function(
           "-f", dockerfile,
           "--destination", paste0(the_image, ":", x),
           sprintf("--context=%s", build_context),
+          build_args,
           "--cache=true"
         ),
         ...


### PR DESCRIPTION
@MarkEdmondson1234 This PR allows `availableSecrets` and `build_args` to be used with `cr_deploy_docker`. This can be very useful when your docker image is trying to pull private packages and you dont want to hard code the secrets. 

```
library(googleCloudRunner)
secret <- cr_build_yaml_secrets("BITBUCKET_PASSWORD", "BITBUCKET_PASSWORD")
cr_deploy_docker(
  local = ".", 
  remote = "my_docker_image",
  image_name = "my_docker_image",
  tag = tag,
  kaniko_cache = TRUE,
  build_args = c('--build-arg=BITBUCKET_PASSWORD'),
  timeout = 1500L,
  secretEnv = "BITBUCKET_PASSWORD",
  availableSecrets = list(secret)
)
```