### PR TITLE
Enable minimal functionality of private worker pools with Cloud Build & Cloud Scheduler

### DIFF
--- a/R/build_admin.R
+++ b/R/build_admin.R
@@ -280,9 +280,15 @@ parse_build_meta_to_obj <- function(o) {
 
 as.gar_Build <- function(x) {
   if (is.BuildOperationMetadata(x)) {
-    bb <- cr_build_status(extract_build_id(x),
-      projectId = x$metadata$build$projectId
-    )
+    # This may be excessively defensive. It's not clear to me why
+    # we can't just call cr_build_status(x) for both cases.
+    if (has_private_worker_pool(x)){
+      bb <- cr_build_status(x)
+    } else {
+      bb <- cr_build_status(extract_build_id(x),
+                            projectId = x$metadata$build$projectId
+      )
+    }
     o <- parse_build_meta_to_obj(bb)
   } else if (is.gar_Build(x)) {
     o <- x # maybe more here later...

--- a/R/build_admin.R
+++ b/R/build_admin.R
@@ -15,10 +15,17 @@ cr_build_status <- function(id = .Last.value,
                             projectId = cr_project_get()) {
   the_id <- extract_build_id(id)
 
-  url <- sprintf(
-    "https://cloudbuild.googleapis.com/v1/projects/%s/builds/%s",
-    projectId, the_id
-  )
+  if (has_private_worker_pool(id)){
+    url <- sprintf(
+      "https://cloudbuild.googleapis.com/v1/%s",
+      id[["metadata"]][["build"]][["name"]]
+    )
+  } else{
+    url <- sprintf(
+      "https://cloudbuild.googleapis.com/v1/projects/%s/builds/%s",
+      projectId, the_id
+    )
+  }
 
   # cloudbuild.projects.builds.get
   f <- gar_api_generator(url, "GET", data_parse_function = as.gar_Build)

--- a/R/build_do.R
+++ b/R/build_do.R
@@ -68,6 +68,7 @@ cr_build <- function(x,
                      artifacts = NULL,
                      options = NULL,
                      projectId = cr_project_get(),
+                     region = cr_region_get(),
                      launch_browser = interactive()) {
   assert_that(
     is.flag(launch_browser),
@@ -76,10 +77,20 @@ cr_build <- function(x,
 
   timeout <- check_timeout(timeout)
 
-  url <- sprintf(
-    "https://cloudbuild.googleapis.com/v1/projects/%s/builds",
-    projectId
-  )
+  # If options$pool$name exists, use different API endpoint that specifies
+  # the location; region has to match the region of the worker
+  if (has_private_worker_pool(x)){
+    url <- sprintf(
+      "https://cloudbuild.googleapis.com/v1/projects/%s/locations/%s/builds",
+      projectId,
+      region
+    )
+  } else {
+    url <- sprintf(
+      "https://cloudbuild.googleapis.com/v1/projects/%s/builds",
+      projectId
+    )
+  }
 
   if (is.gar_Build(x)) {
     # turn existing build into a valid new build
@@ -127,7 +138,15 @@ is.BuildOperationMetadata <- function(x) {
   inherits(x, "BuildOperationMetadata")
 }
 
-
+has_private_worker_pool <- function(x){
+  if (is.Yaml(x)){
+    has_pool_name <- length(x[["options"]][["pool"]][["name"]]) > 0
+  }
+  if (is.BuildOperationMetadata(x)){
+    has_pool_name <- length(x[["metadata"]][["build"]][["options"]][["pool"]][["name"]]) > 0
+  }
+  has_pool_name
+}
 
 extract_logs <- function(o) {
   if (is.BuildOperationMetadata(o)) {

--- a/R/build_do.R
+++ b/R/build_do.R
@@ -139,6 +139,7 @@ is.BuildOperationMetadata <- function(x) {
 }
 
 has_private_worker_pool <- function(x){
+  has_pool_name <- FALSE
   if (is.Yaml(x)){
     has_pool_name <- length(x[["options"]][["pool"]][["name"]]) > 0
   }

--- a/R/cloudbuild_schedule.R
+++ b/R/cloudbuild_schedule.R
@@ -56,12 +56,18 @@ cr_schedule_http <- function(build,
   build <- as.gar_Build(build)
   build <- safe_set(build, "status", "QUEUED")
 
-  HttpTarget(
-    httpMethod = "POST",
-    uri = sprintf(
+  if (has_private_worker_pool(build)){
+    uri <- paste0("https://cloudbuild.googleapis.com/v1/",build[["options"]][["pool"]][["name"]])
+  } else {
+    uri <- sprintf(
       "https://cloudbuild.googleapis.com/v1/projects/%s/builds",
       projectId
-    ),
+    )
+  }
+
+  HttpTarget(
+    httpMethod = "POST",
+    uri = uri,
     body = build,
     oauthToken = list(serviceAccountEmail = email)
   )


### PR DESCRIPTION
This is an extremely minimal first pass. My aim here was to make creating & scheduling a build work when the yaml specifies a private worker pool by setting the option

```
pool:
  name: projects/{projects}/locations/{location}/workerPools/{worker-name}
```

The general strategy I took was to create a helper function that tests whether the build yaml has set the above option, and then create the API uri differently in that case. I've verified that a basic workflow using `cr_build()`, `cr_schedule_http()` & `cr_schedule()` work with private worker pools with these changes. I couldn't run the tests, even with no changes, tons of stuff was failing right out of the gate, so I'm not 100% sure of how much other stuff I might have broken with these changes.

If you think this is a decent approach I'll try manually testing other parts of the package to see if there are other places similar adjustments may be needed to handle private worker pools.